### PR TITLE
[ENTESB-10817] Openshift 4.1 + FMP: Unexpected response (403 Forbidden), to the authorization request. Missing header:[Location]!

### DIFF
--- a/openshift-client/pom.xml
+++ b/openshift-client/pom.xml
@@ -144,6 +144,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20180813</version>
+    </dependency>
+
     <!-- Compile Only Dependencies -->
     <dependency>
       <groupId>io.sundr</groupId>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTESB-10817

OpenShift 4 should first read authorization server URL from JSON response and then send authorization request.

OpenShift 3 falls back to former authorization process.

JSON parser dependency added for convenience, since obtaining the URL would be awful without it. 