### PR TITLE
ENTESB-11929: [ER1][OCP4][SB1] Watching configmap throws exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 3.1.12 (To be released)
   Bugs
    * Fix #1070 : Error parsing openshift json template with the latest version
+   * Fix #1667: Origin header for watch requests had a port of -1 when no port specified
 
   Improvements
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -143,10 +143,15 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
     httpUrlBuilder.addQueryParameter("watch", "true");
 
+    String origin = requestUrl.getProtocol() + "://" + requestUrl.getHost();
+    if (requestUrl.getPort() != -1) {
+        origin += ":" + requestUrl.getPort();
+    }
+
     Request request = new Request.Builder()
       .get()
       .url(httpUrlBuilder.build())
-      .addHeader("Origin", requestUrl.getProtocol() + "://" + requestUrl.getHost() + ":" + requestUrl.getPort())
+      .addHeader("Origin", origin)
       .build();
 
     webSocket = clonedClient.newWebSocket(request, new WebSocketListener() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchHTTPManager.java
@@ -149,10 +149,15 @@ public class WatchHTTPManager<T extends HasMetadata, L extends KubernetesResourc
 
     httpUrlBuilder.addQueryParameter("watch", "true");
 
+    String origin = requestUrl.getProtocol() + "://" + requestUrl.getHost();
+    if (requestUrl.getPort() != -1) {
+        origin += ":" + requestUrl.getPort();
+    }
+
     final Request request = new Request.Builder()
       .get()
       .url(httpUrlBuilder.build())
-      .addHeader("Origin", requestUrl.getProtocol() + "://" + requestUrl.getHost() + ":" + requestUrl.getPort())
+      .addHeader("Origin", origin)
       .build();
 
     clonedClient.newCall(request).enqueue(new Callback() {


### PR DESCRIPTION
Check for port before setting Origin header for watch requests.
 
When the Kubernetes URL used doesn't specify a port
(e.g., https://example.com/api/v1/...), the origin header for
watch requests ends up with a port of -1 (e.g. https://example.com:-1).
This happens because calling `getPort()` on a java.net.URL object that
does not have a port explicitly specified will always return -1. The
return value was always just inserted into the origin header.

Now, we check for this and only append a port to the origin header if
`getPort()` returns something other than -1. We make this change in both
the WatchConnectionManager and WatchHTTPManager classes.