### PR TITLE
[ENTESB-14511] Quickstarts fails on OCP 4.6

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java
@@ -708,8 +708,8 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
     } catch (MalformedURLException e) {
       throw KubernetesClientException.launderThrowable(forOperationType("watch"), e);
     } catch (KubernetesClientException ke) {
-
-      if (ke.getCode() != 200) {
+      List<Integer> furtherProcessedCodes = Arrays.asList(200, 503);
+      if (! furtherProcessedCodes.contains(ke.getCode())) {
         if(watch != null){
           //release the watch
           watch.close();
@@ -724,7 +724,7 @@ public class BaseOperation<T, L extends KubernetesResourceList, D extends Doneab
         watch.close();
       }
 
-      // If the HTTP return code is 200, we retry the watch again using a persistent hanging
+      // If the HTTP return code is 200 or 503, we retry the watch again using a persistent hanging
       // HTTP GET. This is meant to handle cases like kubectl local proxy which does not support
       // websockets. Issue: https://github.com/kubernetes/kubernetes/issues/25126
       try {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java
@@ -181,9 +181,10 @@ public class WatchConnectionManager<T extends HasMetadata, L extends KubernetesR
 
         // We do not expect a 200 in response to the websocket connection. If it occurs, we throw
         // an exception and try the watch via a persistent HTTP Get.
-        if (response != null && response.code() == HTTP_OK) {
+        // Newer Kubernetes might also return 503 Service Unavailable in case WebSockets are not supported
+        if (response != null && (response.code() == HTTP_OK || response.code() == 503)) {
           queue.clear();
-          queue.offer(new KubernetesClientException("Received 200 on websocket",
+          queue.offer(new KubernetesClientException("Received " + response.code() + " on websocket",
             response.code(), null));
           response.body().close();
           return;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14511
Upstream PR: https://github.com/fabric8io/kubernetes-client/pull/2446

On newer Kubernetes, when WebSockets are not available, the server returns 503 Service Unavailable status code (formerly it returned 200 OK). Watch service needs to consider this response code too when trying to fall back to HTTP watch.