### PR TITLE
Fix client.adapt behavior for OpenShiftClient on OpenShift 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## CHANGELOG
 
 ### 4.7-SNAPSHOT
+
 #### Bugs
 * Fix #1833: Respect the termination grace period from the Kubernetes resource by default
 * Fix #1827: Fix `withGracePeriod` and `withPropagationPolicy` return type to safely chain further DSL methods and default GracePeriod to 30s
 * Fix #1828: VersionInfo date parsing of year
 * Fix #1844: KubernetesDeserializer can now handle ArrayNode.
+* `client.isAdaptable(OpenShiftClient.class)` doesn't work on OpenShift 4
 
 
 #### Improvements

--- a/kubernetes-examples/src/main/java/io/fabric8/openshift/examples/LoginExample.java
+++ b/kubernetes-examples/src/main/java/io/fabric8/openshift/examples/LoginExample.java
@@ -15,8 +15,11 @@
  */
 package io.fabric8.openshift.examples;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.openshift.api.model.Project;
+import io.fabric8.openshift.api.model.ProjectList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,15 +28,15 @@ public class LoginExample {
   private static final Logger logger = LoggerFactory.getLogger(LoginExample.class);
 
   public static void main(String[] args) {
-
     try (DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient(new ConfigBuilder()
       .withMasterUrl("cluster_url")
       .withUsername("my_username")
       .withPassword("my_password")
       .build())) {
-
       final OpenShiftClient openShiftClient = kubernetesClient.adapt(OpenShiftClient.class);
-      logger.info(openShiftClient.projects().list().toString());
+      logger.info("Login Successful");
+      final ProjectList pl = openShiftClient.projects().list();
+      pl.getItems().stream().map(Project::getMetadata).map(ObjectMeta::getName).forEach(logger::info);
     }
   }
 }

--- a/kubernetes-itests/src/test/java/io/fabric8/commons/ClusterEntity.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/commons/ClusterEntity.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.commons;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.NamedCluster;
+import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.kubernetes.client.VersionInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+public class ClusterEntity {
+
+  public static final String FRAMEWORK = "framework";
+  public static final String ARQUILLIAN = "arquillian";
+
+  public static final String NON_NUMERIC_CHARACTERS = "[^\\d.]";
+  public static final String EMPTY = "";
+
+  public static void apply(InputStream inputStream) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      String namespace = getArquillianNamespace();
+      if (namespace != null) {
+        client.load(inputStream).inNamespace(namespace).createOrReplace();
+      }
+    }
+  }
+
+  public static void apply(HasMetadata kubernetesResource) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      String namespace = getArquillianNamespace();
+      if (namespace != null) {
+        client.resource(kubernetesResource).inNamespace(namespace).createOrReplace();
+      }
+    }
+  }
+
+  public static void remove(InputStream inputStream) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      List<HasMetadata> items = client.load(inputStream).get();
+      client.resourceList(items).inNamespace(getArquillianNamespace()).withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+    }
+  }
+
+  public static void remove(HasMetadata kubernetesResource) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      client.resource(kubernetesResource).inNamespace(getArquillianNamespace()).withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+    }
+  }
+
+  public static boolean kubernetesVersionAtLeast(String majorVersion, String minorVersion) {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      VersionInfo versionInfo = client.getVersion();
+      String clusterMajorVersion = versionInfo.getMajor().replaceAll(NON_NUMERIC_CHARACTERS, EMPTY);
+      String clusterMinorVersion = versionInfo.getMinor().replaceAll(NON_NUMERIC_CHARACTERS, EMPTY);
+
+      if (Integer.parseInt(majorVersion) < Integer.parseInt(clusterMajorVersion)) {
+        return true;
+      }
+
+      return Integer.parseInt(clusterMajorVersion) >= Integer.parseInt(majorVersion) &&
+        Integer.parseInt(clusterMinorVersion) >= Integer.parseInt(minorVersion);
+    }
+  }
+
+  public static String getArquillianNamespace() {
+    try (KubernetesClient client = new DefaultKubernetesClient()) {
+      NamespaceList namespaceList = client.namespaces().list();
+      for (Namespace namespace : namespaceList.getItems()) {
+
+        // Namespace should not be in terminating state and it should have
+        // labels.
+        if (namespace.getMetadata().getDeletionTimestamp() == null) {
+          if (namespace.getMetadata().getLabels() != null) {
+            Map<String, String> labels = namespace.getMetadata().getLabels();
+            if (labels.containsKey(FRAMEWORK) &&
+              labels.get(FRAMEWORK).equals(ARQUILLIAN)) {
+              return namespace.getMetadata().getName();
+            }
+          }
+
+          if (namespace.getMetadata().getName().startsWith("itest-")) {
+            return namespace.getMetadata().getName();
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  public static String getClusterUrl() throws IOException {
+    io.fabric8.kubernetes.api.model.Config kubeConfig = Serialization.yamlMapper().readValue(new File(Config.getKubeconfigFilename()), io.fabric8.kubernetes.api.model.Config.class);
+
+    String currentContext = kubeConfig.getCurrentContext();
+    NamedContext currentNamedContext = kubeConfig.getContexts().stream()
+      .filter(c -> c.getName().equals(currentContext)).findFirst()
+      .orElse(null);
+    if (currentNamedContext != null) {
+      String clusterInContext = currentNamedContext.getContext().getCluster();
+      NamedCluster namedCluster = kubeConfig.getClusters().stream()
+        .filter(c -> c.getName().equals(clusterInContext))
+        .findFirst()
+        .orElse(null);
+      if (namedCluster != null) {
+        return namedCluster.getCluster().getServer();
+      }
+    }
+    return null;
+  }
+}

--- a/kubernetes-itests/src/test/java/io/fabric8/openshift/AdaptIT.java
+++ b/kubernetes-itests/src/test/java/io/fabric8/openshift/AdaptIT.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.openshift;
+
+import io.fabric8.commons.ClusterEntity;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class AdaptIT {
+  @Test
+  public void testAdaptToOpenShift() throws IOException {
+    // Given
+    String clusterUrl = ClusterEntity.getClusterUrl();
+    Config config = getConfig(clusterUrl, "developer", "developer");
+    KubernetesClient kubernetesClient = new DefaultKubernetesClient(config);
+
+    // When + Then
+    assertNotNull(kubernetesClient.adapt(OpenShiftClient.class));
+  }
+
+  @Test
+  public void testIsAdaptable() throws IOException {
+    // Given
+    String clusterUrl = ClusterEntity.getClusterUrl();
+    Config config = getConfig(clusterUrl, "developer", "developer");
+    KubernetesClient kubernetesClient = new DefaultKubernetesClient(config);
+
+    // When + Then
+    assertTrue(kubernetesClient.isAdaptable(OpenShiftClient.class));
+  }
+
+  private Config getConfig(String clusterUrl, String username, String password) {
+    return new ConfigBuilder()
+      .withMasterUrl(clusterUrl)
+      .withUsername(username)
+      .withPassword(password)
+      .build();
+  }
+}

--- a/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AdaptTest.java
+++ b/kubernetes-tests/src/test/java/io/fabric8/openshift/client/server/mock/AdaptTest.java
@@ -16,19 +16,24 @@
 
 package io.fabric8.openshift.client.server.mock;
 
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
 import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.mockwebserver.utils.ResponseProvider;
+import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
-import java.io.IOException;
+import java.net.HttpURLConnection;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableRuleMigrationSupport
 public class AdaptTest {
@@ -53,5 +58,46 @@ public class AdaptTest {
     OpenShiftClient oclient = client.adapt(OpenShiftClient.class);
     assertNotNull(client.adapt(OkHttpClient.class));
     assertNotNull(oclient.adapt(OkHttpClient.class));
+  }
+
+  @Test
+  void testCheckIfAvailableAPIGroupsContainOpenShiftOpenShift4() {
+    // Given
+    String authorizationEndpoint = server.getClient().getMasterUrl() + "oauth/authorize";
+    server.expect().withPath("/apis").andReturn(HttpURLConnection.HTTP_UNAUTHORIZED, null).once();
+    server.expect().get().withPath("/.well-known/oauth-authorization-server")
+      .andReturn(HttpURLConnection.HTTP_OK, "{\"authorization_endpoint\":\"" + authorizationEndpoint + "\"}")
+      .once();
+    server.expect().get().withPath("/oauth/authorize?response_type=token&client_id=openshift-challenging-client")
+      .andReply(new ResponseProvider<Object>() {
+        @Override
+        public Object getBody(RecordedRequest recordedRequest) { return null; }
+
+        @Override
+        public int getStatusCode(RecordedRequest recordedRequest) { return HttpURLConnection.HTTP_MOVED_TEMP; }
+
+        @Override
+        public Headers getHeaders() {
+          return new Headers.Builder()
+            .add("Location", server.getClient().getMasterUrl() + "oauth/token/implicit#access_token=sha256~UkDpAaw0AARKGVvJ0nypSjIDGGLMyxuS9ORWVyMQ2F8&expires_in=86400&scope=user%3Afull&token_type=Bearer")
+            .build();
+        }
+
+        @Override
+        public void setHeaders(Headers headers) { }
+      }).once();
+    server.expect().withPath("/apis").andReturn(HttpURLConnection.HTTP_OK, new APIGroupListBuilder()
+      .addToGroups(new APIGroupBuilder().withName("security.internal.openshift.io").build()))
+      .once();
+
+    KubernetesClient client = server.getClient();
+    client.getConfiguration().setUsername("foo");
+    client.getConfiguration().setPassword("foo-pwd");
+
+    // When
+    boolean isOpenShiftAdaptable = client.isAdaptable(OpenShiftClient.class);
+
+    // Then
+    assertTrue(isOpenShiftAdaptable);
   }
 }

--- a/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
+++ b/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java
@@ -149,7 +149,7 @@ public class DefaultOpenShiftClient extends BaseClient implements NamespacedOpen
     return clientWithOpenShiftOAuthInterceptor(null, config);
   }
 
-  private static OkHttpClient clientWithOpenShiftOAuthInterceptor(OkHttpClient httpClient, Config config) {
+  static OkHttpClient clientWithOpenShiftOAuthInterceptor(OkHttpClient httpClient, Config config) {
     OkHttpClient.Builder builder = httpClient != null ?
       httpClient.newBuilder().authenticator(Authenticator.NONE) :
       new OkHttpClient.Builder().authenticator(Authenticator.NONE);


### PR DESCRIPTION
OpenshiftAdapterSupport hits `/apis` endpoint for getting list of
available APIGroups. This fails for OpenShift 4 since OpenShift 4 gives
403. Modify OpenShiftAdapterSupport.isOpenShiftAPIGroups to use
OkHttpClient instance with added `OpenShiftOAuthInterceptor`

relates to https://issues.redhat.com/browse/ENTESB-15700